### PR TITLE
Update pickadate to v3.0.5

### DIFF
--- a/vendor/assets/javascripts/pickadate/picker.date.js
+++ b/vendor/assets/javascripts/pickadate/picker.date.js
@@ -1,6 +1,6 @@
 
 /*!
- * Date picker for pickadate.js v3.0.4
+ * Date picker for pickadate.js v3.0.5
  * http://amsul.github.io/pickadate.js/date.htm
  */
 
@@ -458,7 +458,7 @@ DatePicker.prototype.parse = function( type, value, options ) {
 DatePicker.prototype.formats = (function() {
 
     // Return the length of the first word in a collection.
-    var getWordLengthFromCollection = function( string, collection, dateObject ) {
+    function getWordLengthFromCollection( string, collection, dateObject ) {
 
         // Grab the first word from the string.
         var word = string.match( /\w+/ )[ 0 ]
@@ -470,6 +470,11 @@ DatePicker.prototype.formats = (function() {
 
         // Return the length of the word.
         return word.length
+    }
+
+    // Get the length of the first word in a string.
+    function getFirstWordLength( string ) {
+        return string.match( /\w+/ )[ 0 ].length
     }
 
     return {

--- a/vendor/assets/javascripts/pickadate/picker.js
+++ b/vendor/assets/javascripts/pickadate/picker.js
@@ -1,6 +1,6 @@
 
 /*!
- * pickadate.js v3.0.4, 2013/05/25
+ * pickadate.js v3.0.5, 2013/06/14
  * By Amsul, http://amsul.ca
  * Hosted on http://amsul.github.io/pickadate.js
  * Licensed under MIT

--- a/vendor/assets/javascripts/pickadate/picker.time.js
+++ b/vendor/assets/javascripts/pickadate/picker.time.js
@@ -1,6 +1,6 @@
 
 /*!
- * Time picker for pickadate.js v3.0.4
+ * Time picker for pickadate.js v3.0.5
  * http://amsul.github.io/pickadate.js/time.htm
  */
 

--- a/vendor/assets/javascripts/pickadate/translations/no_NO.js
+++ b/vendor/assets/javascripts/pickadate/translations/no_NO.js
@@ -1,12 +1,12 @@
 // Norwegian
 
 $.extend( $.fn.pickadate.defaults, {
-    monthsFull: [ 'janaur', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember' ],
+    monthsFull: [ 'januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember' ],
     monthsShort: [ 'jan', 'feb', 'mar', 'apr', 'mai', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'des' ],
     weekdaysFull: [ 'søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag' ],
     weekdaysShort: [ 'søn','man','tir', 'ons', 'tor', 'fre', 'lør' ],
     today: 'i dag',
-    clear: 'slette',
+    clear: 'nullstill',
     firstDay: 1,
     format: 'dd. mmm. yyyy',
     formatSubmit: 'yyyy/mm/dd'


### PR DESCRIPTION
There is a small upstream update to pickadate that only contains two fixes - listed below.

https://github.com/amsul/pickadate.js/issues/145
https://github.com/amsul/pickadate.js/pull/137

The first one (145) is the important one as it includes a fix for a missing function which results in an error.  I've updated the relevant files here accordingly.  

Hope this is helpful - please let me know if there are any changes I should make in order to ensure this PR has what's needed.

Thanks!
