### PR TITLE
Adding the --create-dirs options to curl.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ namespace :pickadate do
   task :download do
     require 'fileutils'
 
-    system "curl https://github.com/amsul/pickadate.js/archive/gh-pages.zip -f -L -o tmp/pickadate.zip"
+    system "curl https://github.com/amsul/pickadate.js/archive/gh-pages.zip -f -L --create-dirs -o tmp/pickadate.zip"
     system "unzip tmp/pickadate.zip -d tmp/"
     system "rm tmp/pickadate.zip"
 


### PR DESCRIPTION
In order to make update easier, we can avoid the need of creating a
tmp dir by hand on recently cloned repos.
